### PR TITLE
Allow both left and right hands to be used on the same base mesh

### DIFF
--- a/Assets/ExampleUnlitHideArmShader/UnlitHideArmShader.shader
+++ b/Assets/ExampleUnlitHideArmShader/UnlitHideArmShader.shader
@@ -3,7 +3,8 @@
 	Properties
 	{
 		_MainTex ("Texture", 2D) = "white" {}
-		_EnableFakeArm ("Enable Fake arm (for use with gesture animation)", Float) = 1
+		_EnableFakeArm ("Enable Fake right arm (for use with gesture animation)", Float) = 1
+		_EnableFakeLeftArm ("Enable Fake left arm (for use with gesture animation)", Float) = 0
 	}
 	SubShader
 	{
@@ -40,6 +41,7 @@
 			float4 _MainTex_ST;
 
 			float _EnableFakeArm;
+			float _EnableFakeLeftArm;
 			
 			v2f vert (appdata v)
 			{
@@ -57,6 +59,9 @@
                 for (int i = 0; i < 3; i ++)
                 {
                     if (_EnableFakeArm > 0.5 && IN[i].color.g == 0 && IN[i].color.b == 0) {
+                        return;
+                    }
+                    if (_EnableFakeLeftArm > 0.5 && IN[i].color.r == 0 && IN[i].color.g == 0) {
                         return;
                     }
                     tristream.Append(IN[i]);

--- a/Assets/MeshPosing/Editor/ConstructFakeArm.cs
+++ b/Assets/MeshPosing/Editor/ConstructFakeArm.cs
@@ -178,6 +178,8 @@ public class ConstructFakeArm : EditorWindow {
         sourceMesh.GetUVs (3, srcUV4);
         List<Vector3> srcVertices = new List<Vector3>();
         sourceMesh.GetVertices(srcVertices);
+        List<Color> srcColors = new List<Color>();
+        sourceMesh.GetColors(srcColors);
         List<Vector3> srcNormals = new List<Vector3>();
         sourceMesh.GetNormals(srcNormals);
         List<Vector4> srcTangents = new List<Vector4>();
@@ -347,9 +349,11 @@ public class ConstructFakeArm : EditorWindow {
             }
             BoneWeight bw = srcBoneWeights[i];
             if (sumWeight(bw, lowerArmBones) + sumWeight(bw, armBoneIdx) >= SHOULDER_HIDE_DUPLICATE_THRESH) {
-                newColors.Add(Color.red);
-            } else {
+                newColors.Add(isRight ? Color.red : Color.blue);
+            } else if (i >= srcColors.Count || (srcColors[i].r <= 0.5 && srcColors[i].b <= 0.5)) {
                 newColors.Add(Color.white);
+            } else {
+                newColors.Add(srcColors[i]);
             }
         }
         for (int i = size; i < newVertCount; i++) {


### PR DESCRIPTION
Use red for right hand vertices and blue for left hand vertices when deciding which arm to hide. The downside of this approach is a different property needs to be animated for each side and a bit more complexity in the base shader..